### PR TITLE
Fixing Issue #18: automake-1.14 compatibility

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -74,6 +74,12 @@ elif (automake-1.12 --version) < /dev/null > /dev/null 2>&1; then
 elif (automake-1.13 --version) < /dev/null > /dev/null 2>&1; then
    AUTOMAKE=automake-1.13
    ACLOCAL=aclocal-1.13
+elif (automake-1.14 --version) < /dev/null > /dev/null 2>&1; then
+   AUTOMAKE=automake-1.14
+   ACLOCAL=aclocal-1.14
+elif (automake --version) < /dev/null > /dev/null 2>&1; then
+   AUTOMAKE=automake
+   ACLOCAL=aclocal
 elif (automake-1.6 --version) < /dev/null > /dev/null 2>&1; then
    AUTOMAKE=automake-1.6
    ACLOCAL=aclocal-1.6


### PR DESCRIPTION
autogen.sh currently doesn't recognize automake-1.14 (or any versions of
automake newer than automake-1.13). I've tried to fix this in autogen.sh
by both explicitly adding automake-1.14 and just adding automake to the
long list of `elif`s.
