### PR TITLE
restoring alpha channel after the Heal transparency action

### DIFF
--- a/PluginScripts/plugin-heal-transparency.py
+++ b/PluginScripts/plugin-heal-transparency.py
@@ -62,6 +62,9 @@ def heal_transparency(timg, tdrawable, samplingRadiusParam=50, orderParam=2):
   
   # restore selection
   pdb.gimp_image_select_item(timg, CHANNEL_OP_REPLACE, org_selection)
+  
+  # restore alpha
+  pdb.gimp_layer_add_alpha(tdrawable)
  
   # Clean up (comment out to debug)
   pdb.gimp_image_undo_group_end(timg)


### PR DESCRIPTION
When we used the heal transparency we lost the alpha channel settings. We need to restore alpha channel after the heal selection is done. That's what this change is about.

It'd be cool to merge it, cause now It's needed to add alpha channel manually every single time after script is called.