### PR TITLE
Use printf instead of echo -n in autogen.sh

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -39,7 +39,7 @@ echo
 
 DIE=0
 
-echo -n "checking for autoconf >= $AUTOCONF_REQUIRED_VERSION ... "
+printf "checking for autoconf >= %s ... " "$AUTOCONF_REQUIRED_VERSION"
 if (autoconf --version) < /dev/null > /dev/null 2>&1; then
     VER=`autoconf --version \
          | grep -m 1 -iw autoconf | sed "s/.* \([0-9.]*\)[-a-z0-9]*$/\1/"`
@@ -52,7 +52,7 @@ else
     DIE=1;
 fi
 
-echo -n "checking for automake >= $AUTOMAKE_REQUIRED_VERSION ... "
+printf "checking for automake >= %s ... " "$AUTOMAKE_REQUIRED_VERSION"
 if (automake-1.7 --version) < /dev/null > /dev/null 2>&1; then
    AUTOMAKE=automake-1.7
    ACLOCAL=aclocal-1.7
@@ -97,7 +97,7 @@ fi
 #    check_version $VER $AUTOMAKE_REQUIRED_VERSION
 #fi
 
-echo -n "checking for glib-gettextize >= $GLIB_REQUIRED_VERSION ... "
+printf "checking for glib-gettextize >= %s ... " "$GLIB_REQUIRED_VERSION"
 if (glib-gettextize --version) < /dev/null > /dev/null 2>&1; then
     VER=`glib-gettextize --version \
          | grep glib-gettextize | sed "s/.* \([0-9.]*\)/\1/"`
@@ -110,7 +110,7 @@ else
     DIE=1
 fi
 
-echo -n "checking for intltool >= $INTLTOOL_REQUIRED_VERSION ... "
+printf "checking for intltool >= %s ... " "$INTLTOOL_REQUIRED_VERSION"
 if (intltoolize --version) < /dev/null > /dev/null 2>&1; then
     VER=`intltoolize --version \
          | grep intltoolize | sed "s/.* \([0-9.]*\)/\1/"`


### PR DESCRIPTION
`echo -n` is not portable; `printf` is.

Before this change, here is what running autogen.sh looks like on macOS:

```
-n checking for autoconf >= 2.54 ...
yes (version 2.69)
-n checking for automake >= 1.6 ...
-n checking for glib-gettextize >= 2.0.0 ...
yes (version 2.58.3)
-n checking for intltool >= 0.17 ...
yes (version 0.51.0)
```

After this change, it looks the way you intended:

```
checking for autoconf >= 2.54 ... yes (version 2.69)
checking for automake >= 1.6 ... checking for glib-gettextize >= 2.0.0 ... yes (version 2.58.3)
checking for intltool >= 0.17 ... yes (version 0.51.0)
```

The missing version information and newline after checking automake is an unrelated issue that I don't intend to address in this PR.