### PR TITLE
Fix check_version in autogen.sh

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -22,9 +22,14 @@ test -z "$srcdir" && srcdir=.
 ORIGDIR=`pwd`
 cd $srcdir
 
+ver ()
+{
+    echo "$1" | awk -F. '{printf("%d%03d%03d%03d\n",$1,$2,$3,$4);}'
+}
+
 check_version ()
 {
-    if expr $1 \>= $2 > /dev/null; then
+    if [ "`ver "$1"`" -ge "`ver "$2"`" ]; then
 	echo "yes (version $1)"
     else
 	echo "Too old (found version $1)!"
@@ -91,11 +96,11 @@ else
     DIE=1
 fi
 
-#if test x$AUTOMAKE != x; then
-#    VER=`$AUTOMAKE --version \
-#         | grep automake | sed "s/.* \([0-9.]*\)[-a-z0-9]*$/\1/"`
-#    check_version $VER $AUTOMAKE_REQUIRED_VERSION
-#fi
+if test x$AUTOMAKE != x; then
+    VER=`$AUTOMAKE --version \
+         | grep automake | sed "s/.* \([0-9.]*\)[-a-z0-9]*$/\1/"`
+    check_version $VER $AUTOMAKE_REQUIRED_VERSION
+fi
 
 echo -n "checking for glib-gettextize >= $GLIB_REQUIRED_VERSION ... "
 if (glib-gettextize --version) < /dev/null > /dev/null 2>&1; then


### PR DESCRIPTION
Fix `check_version` to actually do a version number comparison instead of
a string comparison. The method used assumes version numbers have no
more than four dot-separated components and that each component has no
more than three digits. These limitations are expected to be acceptable
here.

Also uncomment the version check for automake which now won't give a
false error with automake versions greater than 1.10.

Output from running autogen.sh before these changes (but including the changes from #84):

```
checking for autoconf >= 2.54 ... yes (version 2.69)
checking for automake >= 1.6 ... checking for glib-gettextize >= 2.0.0 ... yes (version 2.58.3)
checking for intltool >= 0.17 ... yes (version 0.51.0)
```

Output after uncommenting the automake version check but before fixing `check_version`:

```
checking for autoconf >= 2.54 ... yes (version 2.69)
checking for automake >= 1.6 ... Too old (found version 1.16.3)!
checking for glib-gettextize >= 2.0.0 ... yes (version 2.58.3)
checking for intltool >= 0.17 ... yes (version 0.51.0)

Please install/upgrade the missing tools and call me again.
```

Output after also fixing `check_version`:

```
checking for autoconf >= 2.54 ... yes (version 2.69)
checking for automake >= 1.6 ... yes (version 1.16.3)
checking for glib-gettextize >= 2.0.0 ... yes (version 2.58.3)
checking for intltool >= 0.17 ... yes (version 0.51.0)
```