### PR TITLE
Fix format-security warning in debug.c

### DIFF
--- a/enginePlugin/debug.c
+++ b/enginePlugin/debug.c
@@ -8,6 +8,5 @@
 void
 debug(const char * message)
 {
-  g_printerr(message);
-  g_printerr("\n");
+  g_message("%s", message);
 }


### PR DESCRIPTION
`g_printerr()` and related take an `fprint()` style format string as first parameter, followed by arguments for that `fprint()` format string – just a string was supplied here. As this function was only supplying a string, compilers would raise a `format-security` warning, which is commonly raised as an error (`-Werror=format-security`), stopping the compilation.

Additionally, [`g_printerr()` “should not be used from within libraries.”](https://docs.gtk.org/glib/func.printerr.html) Instead, it is being replaced here by the [`g_message()` convenience macro](https://docs.gtk.org/glib/func.message.html), which also takes care of inserting newlines if needed.