### PR TITLE
Fix Windows console window for resynthesizer plugin

### DIFF
--- a/enginePlugin/meson.build
+++ b/enginePlugin/meson.build
@@ -55,4 +55,5 @@ executable(plugin_name,
   include_directories: resynthesizer_inc,
   install: true,
   install_dir: gimpplugindir / plugin_name,
+  win_subsystem: 'windows',
 )


### PR DESCRIPTION
On Windows, the resynthesizer plugin opens a console window each time it runs because the executable is built as a console subsystem app.

This change builds the plugin executable with win_subsystem: 'windows' so it runs without spawning a console window.

Tested on Windows with GIMP 3.0.6 (resynthesizer3 branch).
